### PR TITLE
[www-client/firefox-l10n-*] introduce scripts and eclass

### DIFF
--- a/eclass/firefox-l10n.eclass
+++ b/eclass/firefox-l10n.eclass
@@ -1,0 +1,51 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+[[ ${EAPI} != 4 ]] && die "only EAPI 4 is supported"
+
+# note: no Gentoo patches are applied, but that's unlikely they
+# would touch the locale files
+
+MOZ_ESR=${MOZ_ESR:-}
+
+MOZ_LANGS=( ${PN#firefox-l10n-} )
+
+# Convert the ebuild version to the upstream mozilla version, used by mozlinguas
+# (copied from a Firefox ebuild)
+MOZ_PV="${PV/_alpha/a}" # Handle alpha for SRC_URI
+MOZ_PV="${MOZ_PV/_beta/b}" # Handle beta for SRC_URI
+MOZ_PV="${MOZ_PV/_rc/rc}" # Handle rc for SRC_URI
+
+if [[ ${MOZ_ESR} == 1 ]]; then
+	# ESR releases have slightly version numbers
+	MOZ_PV="${MOZ_PV}esr"
+fi
+
+MOZ_PN="firefox"
+
+MOZ_FTP_URI="ftp://ftp.mozilla.org/pub/${MOZ_PN}/releases/"
+
+inherit toolchain-funcs mozlinguas
+# for mozextension.eclass, hopefully temporary
+inherit versionator
+
+DESCRIPTION="Firefox language pack (${MOZ_LANGS[0]})"
+HOMEPAGE="http://www.mozilla.com/firefox"
+
+LICENSE="MPL-2.0 GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="!<www-client/firefox-${PV}"
+
+S=${WORKDIR}
+
+src_install() {
+	local MOZILLA_FIVE_HOME
+	MOZILLA_FIVE_HOME="/usr/$(get_libdir)/${MOZ_PN}"
+	# we need to fake PN: see mozversion_extension_location
+	# in mozextension.eclass
+	PN=${MOZ_PN} mozlinguas_src_install
+}

--- a/www-client/ebuilds-new-version-Firefox-l10n.sh
+++ b/www-client/ebuilds-new-version-Firefox-l10n.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Script that removes Firefox language ebuilds and creates new ones, usually
+# for a new version.
+
+#   Copyright 2014 Sławomir Nizio
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# The scripts needs to be run within www-client in the overlay; the repository
+# must not have uncommitted changes.
+
+# The script asks interactively for a few parameters:
+# - list of languages (MOZ_LANGS in Firefox ebuild),
+# - new version,
+# - location of the Manifest for Firefox - used as the trick that allows to bump
+#   the packages without downloading the language packs themselves, and adds
+#   correctness to the process (if not security).
+
+e() {
+	echo "$*" >&2
+	exit 1
+}
+
+print_ebuild() {
+	local ver=$1
+
+	cat <<-END
+	# Copyright 1999-2014 Gentoo Foundation
+	# Distributed under the terms of the GNU General Public License v2
+	# \$Header: \$
+
+	EAPI=4
+	inherit firefox-l10n
+END
+}
+
+create_ebuild() {
+	local lang=$1 package_name_prefix=$2 ver=$3
+	[[ $# -ne 3 ]] && e "create_ebuild: expected 3 arguments"
+
+	# firefox-l10n-pl-17.0.1-r1.ebuild
+	local package_name="${package_name_prefix}-${lang}"
+	local ebuild_name=${package_name}-${ver}.ebuild
+
+	echo "=> ${lang} (${ebuild_name})"
+
+	mkdir "${package_name}" || e "mkdir failed"
+	print_ebuild "${ver}" > "${package_name}/${ebuild_name}" \
+		|| e "creating ebuild for ${ebuild_name} failed"
+	cp "${manifest_path}" "${package_name}/Manifest" \
+		|| e "copying Manifest for ${ebuild_name} failed"
+
+	ebuild "${package_name}/${ebuild_name}" manifest \
+		|| e "updating Manifest failed"
+}
+
+if ! git status > /dev/null; then
+	echo "this script removes and copies etc. stuff"
+	echo "for safety, aborting, as you're not in a git repository"
+	exit 2
+fi
+
+if [[ -n $(git status -s) ]]; then
+	# this check is simple but should be good enough
+	echo "your checkout is not \"clean\", aborting"
+	exit 3
+fi
+
+if [[ $(basename "$(realpath .)") != "www-client" ]]; then
+	echo "CWD should be www-client"
+	exit 4
+fi
+
+echo "provide language list, from Firefox ebuild:"
+read -a langs
+
+[[ ${#langs[@]} -eq 0 ]] && e "No langs?"
+
+echo "provide new version number:"
+read new_version
+
+def_manifest_path="/usr/portage/www-client/firefox/Manifest"
+echo "provide location to Firefox's Manifest (${def_manifest_path} if empty):"
+read manifest_path
+
+manifest_path=${manifest_path:-${def_manifest_path}}
+echo "Manifest path: ${manifest_path}"
+[[ -e ${manifest_path} ]] || e "File does not exist."
+
+[[ -z ${new_version} ]] && e "...should not be empty"
+[[ ! ${new_version} =~ ^[0-9] ]] && e "...does not look correct"
+
+package_name_prefix=firefox-l10n
+
+# so that git doesn't remove the current directory if no other files are present
+keepfile=keep-tmp-Fx-l10n
+touch "${keepfile}" || e "creating ${keepfile} failed"
+git rm -r "${package_name_prefix}"-* || e "git rm -r ${package_name_prefix}-* failed"
+
+for lang in "${langs[@]}"; do
+	# see mozlinguas_export in mozlinguas.eclass
+	[[ ${lang} = en || ${lang//-/_} = en_US ]] && continue
+	create_ebuild "${lang}" "${package_name_prefix}" "${new_version}"
+done
+
+rm "${keepfile}" || e "rm failed"
+
+git add . || e "git add failed"

--- a/www-client/install-Firefox-l10n.sh
+++ b/www-client/install-Firefox-l10n.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Install all firefox-l10 packages.
+
+#   Copyright 2014 Sławomir Nizio
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# The packages are expected to be in the same directory this script is in.
+# It exports LINGUAS with all of the possible languages to make sure all
+# of the language packages are installed properly (so that it does not matter
+# what is set in make.conf).
+
+e() {
+	echo "$*" >&2
+	exit 1
+}
+
+inst_cmd() {
+	time emerge -a "$@"
+}
+
+determine_ver() {
+	local pkgname=$1
+	local ebuild
+	for ebuild in "${pkgname}/${pkgname}"-*.ebuild; do
+		ver=${ebuild#${pkgname}/${pkgname}-}
+		ver=${ver%.ebuild}
+		break
+	done
+}
+
+dir=$(dirname "$0")
+
+cd "${dir}" || e "cd $dir failed"
+echo "working in ${PWD}"
+
+packages=()
+LINGUAS=""
+
+ver=
+
+for p in firefox-l10n-*; do
+	if [[ ! -e ${p} ]]; then
+		e "${p} does not exist - no packages in the current directory?"
+	fi
+	packages+=( ${p} )
+	lang=${p#firefox-l10n-}
+	lang=${lang//-/_}
+	LINGUAS+=" ${lang}"
+
+	# determine version from the first ebuild
+	[[ -z ${ver} ]] && determine_ver "${p}"
+done
+
+export LINGUAS
+
+inst_cmd "${packages[@]}"
+
+echo "======="
+# Version is "assumed" because it's determined using only one ebuild in the
+# overlay (versions shouldn't differ, though)
+echo "Listing Firefox language packages that are different than the assumed"
+echo "version ${ver}. If any are found, condider uninstalling them!"
+echo
+qlist -ICv www-client/firefox | while read line; do
+	[[ ${line} = *"-${ver}" ]] || echo "${line}"
+done
+echo
+echo "Listing done."
+echo "======="


### PR DESCRIPTION
Files to manage separate language packs for Firefox.
- firefox-l10n.eclass
- ebuilds-new-version-Firefox-l10n.sh - install ebuild for the new
  version
- install-Firefox-l10n.sh - install the packages on system
## 

The most important question to be asked is: do we want them?
pros:
- A bit smaller disk usage: language files take (using du with no special options) 77M (Entropy package; /usr/lib/firefox/browser/extensions/langpack-*; that's hopefully all), and 157M if all languages are enabled.
- Can provide Firefox language packs for all languages easily and fast, and that doesn't depend on LINGUAS.

neutral:
- Possibly no noticeable gain in startup time (Firefox provided by Entropy seems to start fast, so I didn't measure it further).
- No big maintenance cost: scripts are quick and easy to use. Additional maintenance cost will occur if mozlinguas.eclass or mozextension.eclass (or whatever else, as normal) change so that it needs adjusting. However, the two eclasses don't receive much changes.

cons:
- In this setup, no patches can be applied on the language files (the need is unlikely, though; I asked for confirmation on IRC, but no answer yet).

note:
The script ebuilds-new-version-Firefox-l10n.sh is interactive. It cannot be (easily and robustly) made automated because of the need to extract list of languages (from a Firefox ebuild). There is a note in Firefox ebuilds:
`This list can be updated with scripts/get_langs.sh from the mozilla overlay`
so we may consider trying that if deemed useful. However, there is always a possibility that the resulting list will be different from what is in the ebuild (possibly not a big problem).
