### PR TITLE
[x11-drivers/nvidia-userspace] moving app-admin* to app-eselect*, renami...

### DIFF
--- a/x11-drivers/nvidia-userspace/nvidia-userspace-304.125.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-304.125.ebuild
@@ -26,7 +26,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X"
 RESTRICT="strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? ( app-emulation/emul-linux-x86-xlibs )
 	multilib? ( app-emulation/emul-linux-x86-baselibs )

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-331.67.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-331.67.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-337.25.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-337.25.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X uvm"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-340.46.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-340.46.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X uvm"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-340.58.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-340.58.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X uvm"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-340.76.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-340.76.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X uvm"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-343.36.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-343.36.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X uvm"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (

--- a/x11-drivers/nvidia-userspace/nvidia-userspace-346.35.ebuild
+++ b/x11-drivers/nvidia-userspace/nvidia-userspace-346.35.ebuild
@@ -29,7 +29,7 @@ IUSE="acpi multilib x-multilib kernel_FreeBSD kernel_linux tools +X uvm"
 RESTRICT="bindist mirror strip"
 EMULTILIB_PKG="true"
 
-COMMON="app-admin/eselect-opencl
+COMMON="app-eselect/eselect-opencl
 	kernel_linux? ( >=sys-libs/glibc-2.6.1 )
 	x-multilib? (
 		|| (


### PR DESCRIPTION
moving app-admin* to app-eselect* affects nvidia-userspace, renaming app-admin/eselect-opencl to app-eselect/eselect-opencl