### PR TITLE
[x11-drivers/nvidia-drivers-346-35] adding patch "build error _cr4() functions"

### DIFF
--- a/x11-drivers/nvidia-drivers/files/nvidia-drivers-4.0.patch
+++ b/x11-drivers/nvidia-drivers/files/nvidia-drivers-4.0.patch
@@ -1,0 +1,28 @@
+--- kernel/nv-pat.c~     2015-02-20 02:49:40.000000000 +0100
++++ kernel/nv-pat.c  2015-02-25 07:56:40.000000000 +0100
+@@ -35,8 +35,13 @@
+     unsigned long cr0 = read_cr0();
+     write_cr0(((cr0 & (0xdfffffff)) | 0x40000000));
+     wbinvd();
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 20, 0)
+     *cr4 = read_cr4();
+     if (*cr4 & 0x80) write_cr4(*cr4 & ~0x80);
++#else
++    *cr4 = __read_cr4();
++    if (*cr4 & 0x80) __write_cr4(*cr4 & ~0x80);
++#endif
+     __flush_tlb();
+ }
+ 
+@@ -46,7 +51,11 @@
+     wbinvd();
+     __flush_tlb();
+     write_cr0((cr0 & 0x9fffffff));
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 20, 0)
+     if (cr4 & 0x80) write_cr4(cr4);
++#else
++    if (cr4 & 0x80) __write_cr4(cr4);
++#endif   
+ }
+
+ static int nv_determine_pat_mode(void)

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-346.35.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-346.35.ebuild
@@ -103,7 +103,9 @@ src_prepare() {
 		if kernel_is lt 2 6 9 ; then
 			eerror "You must build this against 2.6.9 or higher kernels."
 		fi
-
+		if kernel_is ge 4 0 ; then
+			epatch "${FILESDIR}"/${PN}-4.0.patch
+		fi
 		# If greater than 2.6.5 use M= instead of SUBDIR=
 #		convert_to_m "${NV_SRC}"/Makefile.kbuild
 	fi


### PR DESCRIPTION
refeering to this discussion: 
https://devtalk.nvidia.com/default/topic/813458/linux/linux-4-0-rc1-346-35-build-error-_cr4-functions-fix/

i wasn't able to compile nvidia-drivers otherwise on 4.0 kernel