### PR TITLE
Eix complains wrong EAPI version (at least 2)

### DIFF
--- a/sys-devel/base-gcc/base-gcc-4.7.3.ebuild
+++ b/sys-devel/base-gcc/base-gcc-4.7.3.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
+EAPI=2
+
 PATCH_VER="1.0"
 UCLIBC_VER="1.0"
 


### PR DESCRIPTION
"Building database (/var/cache/eix/portage.eix) ..
[0] 'gentoo' /usr/portage/ (cache: metadata-md5-or-flat)
     Reading category 163|163 (100%) Finished             
[1] 'sabayon-distro' /var/lib/layman/sabayon-distro (cache: parse|ebuild*#metadata-md5#metadata-assign#assign)
     Reading category 136|163 ( 83%): sys-devel .. * ERROR: sys-devel/base-gcc-4.7.3::sabayon-distro failed (depend phase):
 *   Need to upgrade to at least EAPI=2
 * 
 * Call stack:
 *               ebuild.sh, line 550:  Called source '/var/lib/layman/sabayon-distro/sys-devel/base-gcc/base-gcc-4.7.3.ebuild'
 *   base-gcc-4.7.3.ebuild, line  21:  Called inherit 'eutils' 'toolchain'
 *               ebuild.sh, line 280:  Called __qa_source '/usr/portage/eclass/toolchain.eclass'
 *               ebuild.sh, line  80:  Called source '/usr/portage/eclass/toolchain.eclass'
 *        toolchain.eclass, line  29:  Called die
 * The specific snippet of code:
 *   	0|1)    die "Need to upgrade to at least EAPI=2";;
 * 
 * If you need support, post the output of `emerge --info '=sys-devel/base-gcc-4.7.3::sabayon-distro'`,
 * the complete build log and the output of `emerge -pqv '=sys-devel/base-gcc-4.7.3::sabayon-distro'`.
 * Working directory: '/usr/lib64/python2.7/site-packages'
 * S: '/base-gcc-4.7.3'

ebuild failed with status 1
     Reading category 136|163 ( 83%): sys-devel ..
Could not properly execute /var/lib/layman/sabayon-distro/sys-devel/base-gcc/base-gcc-4.7.3.ebuild
     Reading category 163|163 (100%) Finished"

This is the error, only for information :D