### PR TITLE
[app-misc/sabayon-version] Prepare migration to systemd 232 and add support to ~arm64

### DIFF
--- a/app-misc/sabayon-version/sabayon-version.skel
+++ b/app-misc/sabayon-version/sabayon-version.skel
@@ -12,7 +12,7 @@ SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~x86 ~arm64"
 
 IUSE=""
 DEPEND=""
@@ -26,7 +26,6 @@ RDEPEND="!app-admin/eselect-init
 	app-eselect/eselect-python
 	dev-lang/python:${PYTHON_VER}
 	sys-apps/systemd
-	sys-apps/systemd-sysv-utils
 	virtual/man
 	sys-devel/base-gcc:${GCC_VER}
 	sys-devel/gcc-config"
@@ -79,8 +78,4 @@ pkg_postinst() {
 
 	# remove old hal udev rules.d file, if found. sys-apps/hal is long gone.
 	rm -f "${ROOT}/lib/udev/rules.d/90-hal.rules"
-
-	# make sure that systemd is correctly linked to /sbin/init
-	# Drop this in 2015, keep in sync with systemd-sysv-utils
-	ln -sf ../usr/lib/systemd/systemd "${ROOT}/sbin/init" || true
 }


### PR DESCRIPTION
On systemd <= 231 /sbin/init link is created by sys-apns/systemd-sysv-utils but on systemd-232 link is created directly by sys-apps/systemd package.