### PR TITLE
BUG Enable ncurses fallback on all X dependent pinentry

### DIFF
--- a/app-crypt/pinentry-gnome/files/pinentry-0.8.2-ncurses.patch
+++ b/app-crypt/pinentry-gnome/files/pinentry-0.8.2-ncurses.patch
@@ -1,0 +1,1 @@
+../../pinentry-base/files/pinentry-0.8.2-ncurses.patch

--- a/app-crypt/pinentry-gnome/pinentry-gnome-0.9.7-r1.ebuild
+++ b/app-crypt/pinentry-gnome/pinentry-gnome-0.9.7-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-inherit eutils flag-o-matic toolchain-funcs
+inherit autotools eutils flag-o-matic toolchain-funcs
 
 MY_PN=${PN/-gnome}
 MY_P=${P/-gnome}
@@ -28,9 +28,15 @@ DEPEND="${RDEPEND}
 RDEPEND="
 	${CDEPEND}
 	app-crypt/gcr
+	sys-libs/ncurses:0=
 "
 
 S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	epatch "${FILESDIR}/${MY_PN}-0.8.2-ncurses.patch"
+	eautoreconf
+}
 
 src_configure() {
 	[[ "$(gcc-major-version)" -ge 5 ]] && append-cxxflags -std=gnu++11
@@ -40,7 +46,7 @@ src_configure() {
 		--disable-pinentry-emacs \
 		--disable-pinentry-gtk2 \
 		--disable-pinentry-curses \
-		--disable-fallback-curses \
+		--enable-fallback-curses \
 		--disable-pinentry-qt \
 		$(use_with caps libcap) \
 		--enable-libsecret \

--- a/app-crypt/pinentry-gtk2/files/pinentry-0.8.2-ncurses.patch
+++ b/app-crypt/pinentry-gtk2/files/pinentry-0.8.2-ncurses.patch
@@ -1,0 +1,1 @@
+../../pinentry-base/files/pinentry-0.8.2-ncurses.patch

--- a/app-crypt/pinentry-gtk2/pinentry-gtk2-0.9.7-r1.ebuild
+++ b/app-crypt/pinentry-gtk2/pinentry-gtk2-0.9.7-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-inherit eutils flag-o-matic toolchain-funcs
+inherit autotools eutils flag-o-matic toolchain-funcs
 
 MY_PN=${PN/-gtk2}
 MY_P=${P/-gtk2}
@@ -21,12 +21,18 @@ RDEPEND="
 	!app-crypt/pinentry-base[static]
 	caps? ( sys-libs/libcap )
 	x11-libs/gtk+:2
+	sys-libs/ncurses:0=
 "
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	epatch "${FILESDIR}/${MY_PN}-0.8.2-ncurses.patch"
+	eautoreconf
+}
 
 src_configure() {
 	[[ "$(gcc-major-version)" -ge 5 ]] && append-cxxflags -std=gnu++11
@@ -36,7 +42,7 @@ src_configure() {
 		--disable-pinentry-emacs \
 		--enable-pinentry-gtk2 \
 		--disable-pinentry-curses \
-		--disable-fallback-curses \
+		--enable-fallback-curses \
 		--disable-pinentry-qt \
 		$(use_with caps libcap) \
 		--disable-libsecret \

--- a/app-crypt/pinentry-qt4/files/pinentry-0.8.2-ncurses.patch
+++ b/app-crypt/pinentry-qt4/files/pinentry-0.8.2-ncurses.patch
@@ -1,0 +1,1 @@
+../../pinentry-base/files/pinentry-0.8.2-ncurses.patch

--- a/app-crypt/pinentry-qt4/pinentry-qt4-0.9.7-r1.ebuild
+++ b/app-crypt/pinentry-qt4/pinentry-qt4-0.9.7-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-inherit qmake-utils multilib eutils flag-o-matic toolchain-funcs
+inherit autotools qmake-utils multilib eutils flag-o-matic toolchain-funcs
 
 MY_PN=${PN/-qt4}
 MY_P=${P/-qt4}
@@ -22,12 +22,18 @@ RDEPEND="
 	!app-crypt/pinentry-qt5
 	caps? ( sys-libs/libcap )
 	>=dev-qt/qtgui-4.4.1:4
+	sys-libs/ncurses:0=
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
 S=${WORKDIR}/${MY_P}
+
+src_prepare() {
+	epatch "${FILESDIR}/${MY_PN}-0.8.2-ncurses.patch"
+	eautoreconf
+}
 
 src_configure() {
 	local myconf=()
@@ -46,7 +52,7 @@ src_configure() {
 		--disable-pinentry-emacs \
 		--disable-pinentry-gtk2 \
 		--disable-pinentry-curses \
-		--disable-fallback-curses \
+		--enable-fallback-curses \
 		$(use_with caps libcap) \
 		--disable-libsecret \
 		--disable-pinentry-gnome3 \

--- a/app-crypt/pinentry-qt5/files/pinentry-0.8.2-ncurses.patch
+++ b/app-crypt/pinentry-qt5/files/pinentry-0.8.2-ncurses.patch
@@ -1,0 +1,1 @@
+../../pinentry-base/files/pinentry-0.8.2-ncurses.patch

--- a/app-crypt/pinentry-qt5/pinentry-qt5-0.9.7-r1.ebuild
+++ b/app-crypt/pinentry-qt5/pinentry-qt5-0.9.7-r1.ebuild
@@ -23,6 +23,7 @@ RDEPEND="
 	caps? ( sys-libs/libcap )
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
+	sys-libs/ncurses:0=
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
@@ -32,6 +33,7 @@ S=${WORKDIR}/${MY_P}
 
 src_prepare() {
 	epatch "${FILESDIR}/${MY_P}-require-CPP11-for-qt-5-7.patches"
+	epatch "${FILESDIR}/${MY_PN}-0.8.2-ncurses.patch"
 	eautoreconf
 }
 
@@ -50,7 +52,7 @@ src_configure() {
 		--disable-pinentry-emacs \
 		--disable-pinentry-gtk2 \
 		--disable-pinentry-curses \
-		--disable-fallback-curses \
+		--enable-fallback-curses \
 		$(use_with caps libcap) \
 		--disable-libsecret \
 		--disable-pinentry-gnome3 \


### PR DESCRIPTION
This is needed to allow usage of the same pinentry binary when X isn't
available or DISPLAY isn't set such as with remote/ssh sessions.

Steps to reproduce:
* open `xterm`
* `unset DISPLAY`
* run `pinentry`
* type `getpin` and press return

Without the ncurses fallback the binary simply fails with `Cannot connect to X display`.
With the ncurses fallback the ncurses interface is used when X cannot be reached.

Original bug request at: https://bugs.sabayon.org/show_bug.cgi?id=5188