### PR TITLE
Update wireless

### DIFF
--- a/sets/wireless
+++ b/sets/wireless
@@ -1,5 +1,6 @@
 net-wireless/b43-fwcutter
 net-wireless/bcm43xx-fwcutter
+net-wireless/broadcom-sta
 net-wireless/rfkill
 net-wireless/wireless-tools
 sys-firmware/b43-firmware


### PR DESCRIPTION
Adding broadcom-sta. Missing broadcom-sta results in broadcom systems with no working wifi since b43 is blacklisted.