### PR TITLE
Fix sabayon-toolchain.eclass

### DIFF
--- a/eclass/sabayon-toolchain.eclass
+++ b/eclass/sabayon-toolchain.eclass
@@ -126,7 +126,9 @@ _install_basegcc(){
 	fi
 
 	S="${WORKDIR}"/build emake -j1 -C "${CTARGET}/libstdc++-v3/po" DESTDIR="${D}" install || die
-	S="${WORKDIR}"/build emake -j1 -C "${CTARGET}/libgomp" DESTDIR="${D}" install-info || die
+	if use openmp; then
+		S="${WORKDIR}"/build emake -j1 -C "${CTARGET}/libgomp" DESTDIR="${D}" install-info || die
+	fi
 
 	S="${WORKDIR}"/build emake -j1 DESTDIR="${D}" install-target-libquadmath || die
 	if use fortran; then


### PR DESCRIPTION
When sys-devel/base-gcc is built with minimal USE flags (most notably -openmp) it failed the install phase. This patch skips the install-info of libgomp in the same way install-toolexeclibLTLIBRARIES is skipped before in _install_basegcc().

Relevant output of `emerge sys-devel/base-gcc`. Ebuild version bump is irrelevant.
```
make: Entering directory '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/build/armv7a-hardfloat-linux-gnueabi/libstdc++-v3/po'
make[1]: Entering directory '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/build/armv7a-hardfloat-linux-gnueabi/libstdc++-v3/po'
make[1]: Nothing to be done for 'install-exec-am'.
make[1]: Nothing to be done for 'install-data-am'.
make[1]: Leaving directory '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/build/armv7a-hardfloat-linux-gnueabi/libstdc++-v3/po'
make: Leaving directory '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/build/armv7a-hardfloat-linux-gnueabi/libstdc++-v3/po'
make -j8 -j1 -C armv7a-hardfloat-linux-gnueabi/libgomp DESTDIR=/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/image/ install-info 
make: *** armv7a-hardfloat-linux-gnueabi/libgomp: No such file or directory.  Stop.
 * ERROR: sys-devel/base-gcc-5.4.0-r5::nanopi failed (install phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=sys-devel/base-gcc-5.4.0-r5::nanopi'`,
 * the complete build log and the output of `emerge -pqv '=sys-devel/base-gcc-5.4.0-r5::nanopi'`.
 * The complete build log is located at '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/temp/build.log'.
 * The ebuild environment file is located at '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/temp/environment'.
 * Working directory: '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/build'
 * S: '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/build'
 *
 * Please include /usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-devel/base-gcc-5.4.0-r5/work/gcc-build-logs.tar.bz2 in your bug report.
 *
```