### PR TITLE
fix live install name

### DIFF
--- a/x11-themes/sabayon-artwork-gnome/files/org.sabayon.gschema.override-15-r1
+++ b/x11-themes/sabayon-artwork-gnome/files/org.sabayon.gschema.override-15-r1
@@ -57,4 +57,5 @@ locate-pointer=false
 dark-theme=true
 
 [org.gnome.shell]
-favorite-apps=['liveinst.desktop','firefox.desktop', 'evolution.desktop', 'shotwell.desktop', 'rhythmbox.desktop', 'vlc.desktop', 'libreoffice-writer.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Nautilus.desktop']
+favorite-apps=['calamares.desktop','firefox.desktop', 'evolution.desktop', 'shotwell.desktop', 'rhythmbox.desktop', 'vlc.desktop', 
+'libreoffice-writer.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Nautilus.desktop']

--- a/x11-themes/sabayon-artwork-gnome/files/org.sabayon.gschema.override-15-r1
+++ b/x11-themes/sabayon-artwork-gnome/files/org.sabayon.gschema.override-15-r1
@@ -57,5 +57,4 @@ locate-pointer=false
 dark-theme=true
 
 [org.gnome.shell]
-favorite-apps=['calamares.desktop','firefox.desktop', 'evolution.desktop', 'shotwell.desktop', 'rhythmbox.desktop', 'vlc.desktop', 
-'libreoffice-writer.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Nautilus.desktop']
+favorite-apps=['calamares.desktop','firefox.desktop', 'evolution.desktop', 'shotwell.desktop', 'rhythmbox.desktop', 'vlc.desktop', 'libreoffice-writer.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Nautilus.desktop']


### PR DESCRIPTION
liveinst.desktop no longer exists on the gnome desktop swapping out for calamares.desktop - rebuild otherwise the installer gets buried and hard to find